### PR TITLE
Fix LZ4 decompression issue causing OutOfMemory errors

### DIFF
--- a/dumpyara/utils/raw_image.py
+++ b/dumpyara/utils/raw_image.py
@@ -47,9 +47,9 @@ def get_raw_image(partition: str, files_path: Path, output_image_path: Path):
 
 	if lz4_image.is_file():
 		LOGI(f"Decompressing {lz4_image.name} as LZ4 image")
-		with LZ4FrameFile(lz4_image, mode="rb") as lz4_frame_file:
-			with io.open(raw_image, "wb") as raw_image:
-				raw_image.write(lz4_frame_file.read())
+		with LZ4FrameFile(lz4_image, mode="rb") as lz4_frame_file, open(raw_image, "wb") as raw_image_file:
+			while chunk := lz4_frame_file.read(8 * 1024 * 1024):
+				raw_image_file.write(chunk)
 		
 		lz4_image.unlink()
 


### PR DESCRIPTION
Fixes #94

This PR addresses the OutOfMemory error that some users, including myself, encountered when attempting to decompress large LZ4 images (e.g. super.img.lz4).

The problem was caused by loading the entire LZ4 file into memory at once during decompression. This approach worked for smaller files but failed with large archive files, resulting in OutOfMemory exceptions.

The solution implements streaming decompression by:
- Reading and writing the file in chunks (8MB at a time)
- Using a while loop with chunked reading to process the file gradually
- Keeping only small portions of the file in memory

These changes significantly reduce memory usage when handling large LZ4 files, allowing the decompression to complete successfully without running out of memory.